### PR TITLE
Update location of exportMetadata script

### DIFF
--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -89,7 +89,7 @@ fi
 # Grapher database (owid_metadata)
 if [ "${SKIP_DB_DL}" = false ]; then
   echo "Downloading live Grapher metadata database (owid_metadata)"
-  ssh owid-live "cd live && yarn tsn scripts/exportMetadata.ts --with-passwords /tmp/owid_metadata_with_passwords.sql"
+  ssh owid-live "cd live && yarn tsn db/exportMetadata.ts --with-passwords /tmp/owid_metadata_with_passwords.sql"
   rsync -hav --progress owid-live:/tmp/owid_metadata_with_passwords.sql $DL_FOLDER
 fi
 echo "Importing live Grapher metadata database (owid_metadata)"


### PR DESCRIPTION
Currently, running the script fails with a
```
Error: Cannot find module '/home/owid/live/scripts/exportMetadata.ts'
```

This should fix it.